### PR TITLE
update to dart 2

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,16 +1,20 @@
 name: duration
 description: Utilities to make working with 'Duration's easier.
-version: 1.0.0
+version: 2.0.0
 homepage: https://github.com/desktop-dart/duration
 author: Ravi Teja Gudapati <tejainece@gmail.com>
 
 documentation:
 
 environment:
-  sdk: '>=1.20.1 <2.0.0'
+  sdk: '>=2.0.0 <3.0.0'
 
 dependencies:
-  quiver_time: ^1.0.0
+  # waiting for https://github.com/QuiverDart/quiver_time/pull/7
+  quiver_time:
+    git:
+      url: git://github.com/johnpryan/quiver_time.git
+      ref: dart2
 
 dev_dependencies:
-  test: ^0.12.0
+  test: ^1.3.0


### PR DESCRIPTION
This currently uses a forked version of `package:quiver_time` until https://github.com/QuiverDart/quiver_time/pull/7 is released