### PR TITLE
Max Tersity and Hebrew locale

### DIFF
--- a/lib/src/duration.dart
+++ b/lib/src/duration.dart
@@ -35,7 +35,8 @@ String prettyDuration(Duration duration,
     String delimiter,
     String conjunction,
     bool abbreviated = false,
-    bool first = false}) {
+    bool first = false,
+    int maxTersity}) {
   if (abbreviated && delimiter == null) {
     delimiter = ', ';
     spacer = '';
@@ -45,6 +46,9 @@ String prettyDuration(Duration duration,
   }
 
   var out = <String>[];
+  int usedTersity = 0;
+  // If no maxTersity is supplied use the maximum value so all are included
+  maxTersity = maxTersity ?? DurationTersity.all.id;
 
   final partFmt =
       (int amount, String Function(int amount, bool abbreviated) annotater) {
@@ -59,34 +63,49 @@ String prettyDuration(Duration duration,
 
   if (weeks > 0) {
     out.add(partFmt(weeks, locale.week));
+    usedTersity++;
   }
 
-  if (tersity >= DurationTersity.day) {
+  if (tersity >= DurationTersity.day && usedTersity < maxTersity) {
     final int days = duration.inDays - (weeks * 7);
-    if (days > 0) out.add(partFmt(days, locale.day));
+    if (days > 0) {
+      out.add(partFmt(days, locale.day));
+      usedTersity++;
+    }
 
-    if (tersity >= DurationTersity.hour) {
+    if (tersity >= DurationTersity.hour && usedTersity < maxTersity) {
       final int hours = duration.inHours % 24;
-      if (hours > 0) out.add(partFmt(hours, locale.hour));
+      if (hours > 0) {
+        out.add(partFmt(hours, locale.hour));
+        usedTersity++;
+      }
 
-      if (tersity >= DurationTersity.minute) {
+      if (tersity >= DurationTersity.minute && usedTersity < maxTersity) {
         final int minutes = duration.inMinutes % 60;
-        if (minutes > 0) out.add(partFmt(minutes, locale.minute));
+        if (minutes > 0) {
+          out.add(partFmt(minutes, locale.minute));
+          usedTersity++;
+        }
 
-        if (tersity >= DurationTersity.second) {
+        if (tersity >= DurationTersity.second && usedTersity < maxTersity) {
           final int seconds = duration.inSeconds % 60;
-          if (seconds > 0) out.add(partFmt(seconds, locale.second));
+          if (seconds > 0) {
+            out.add(partFmt(seconds, locale.second));
+            usedTersity++;
+          }
 
-          if (tersity >= DurationTersity.millisecond) {
+          if (tersity >= DurationTersity.millisecond && usedTersity < maxTersity) {
             final int milliseconds = duration.inMilliseconds % 1000;
             if (milliseconds > 0) {
               out.add(partFmt(milliseconds, locale.millisecond));
+              usedTersity++;
             }
 
-            if (tersity >= DurationTersity.microsecond) {
+            if (tersity >= DurationTersity.microsecond && usedTersity < maxTersity) {
               final int microseconds = duration.inMicroseconds % 1000;
               if (microseconds > 0 || out.isEmpty) {
                 out.add(partFmt(microseconds, locale.microseconds));
+                usedTersity++;
               }
             } else {
               if (out.isEmpty) out.add(partFmt(0, locale.millisecond));

--- a/lib/src/locale/hebrew.dart
+++ b/lib/src/locale/hebrew.dart
@@ -1,0 +1,86 @@
+part of duration.locale;
+
+class HebrewDurationLocale implements DurationLocale {
+  const HebrewDurationLocale();
+
+  @override
+  String day(int amount, [bool abbreviated = true]) {
+    if (abbreviated) {
+      return 'י';
+    } else {
+      return 'יום';
+    }
+  }
+
+  @override
+  String hour(int amount, [bool abbreviated = true]) {
+    if (abbreviated) {
+      return 'ש';
+    } else {
+      return 'שעה';
+    }
+  }
+
+  @override
+  String microseconds(int amount, [bool abbreviated = true]) {
+    if (abbreviated) {
+      return 'µs';
+    } else {
+      return 'מיקרו שניה';
+    }
+  }
+
+  @override
+  String millisecond(int amount, [bool abbreviated = true]) {
+    if (abbreviated) {
+      return 'ms';
+    } else {
+      return 'מילי שניה';
+    }
+  }
+
+  @override
+  String minute(int amount, [bool abbreviated = true]) {
+    if (abbreviated) {
+      return 'דק.';
+    } else {
+      return 'דקה';
+    }
+  }
+
+  @override
+  String month(int amount, [bool abbreviated = true]) {
+    if (abbreviated) {
+      return 'ח';
+    } else {
+      return 'חודש';
+    }
+  }
+
+  @override
+  String second(int amount, [bool abbreviated = true]) {
+    if (abbreviated) {
+      return 'שנ.';
+    } else {
+      return 'שניה';
+    }
+  }
+
+  @override
+  String week(int amount, [bool abbreviated = true]) {
+    if (abbreviated) {
+      return 'שב.';
+    } else {
+      return 'שבוע';
+    }
+  }
+
+  @override
+  String year(int amount, [bool abbreviated = true]) {
+    if (abbreviated) {
+      return 'שנ.';
+    } else {
+      return 'שנה';
+    }
+  }
+}

--- a/lib/src/locale/hebrew.dart
+++ b/lib/src/locale/hebrew.dart
@@ -8,7 +8,7 @@ class HebrewDurationLocale implements DurationLocale {
     if (abbreviated) {
       return 'י';
     } else {
-      return 'יום';
+      return amount == 1 ? 'יום' : 'ימים';
     }
   }
 
@@ -17,7 +17,7 @@ class HebrewDurationLocale implements DurationLocale {
     if (abbreviated) {
       return 'ש';
     } else {
-      return 'שעה';
+      return amount == 1 ? 'שעה' : 'שעות';
     }
   }
 
@@ -26,7 +26,7 @@ class HebrewDurationLocale implements DurationLocale {
     if (abbreviated) {
       return 'µs';
     } else {
-      return 'מיקרו שניה';
+      return amount == 1 ? 'מיקרו שניה' : 'מיקרו שניות';
     }
   }
 
@@ -35,7 +35,7 @@ class HebrewDurationLocale implements DurationLocale {
     if (abbreviated) {
       return 'ms';
     } else {
-      return 'מילי שניה';
+      return amount == 1 ? 'מילי שניה' : 'מילי שניות';
     }
   }
 
@@ -44,7 +44,7 @@ class HebrewDurationLocale implements DurationLocale {
     if (abbreviated) {
       return 'דק.';
     } else {
-      return 'דקה';
+      return amount == 1 ? 'דקה' : 'דקות';
     }
   }
 
@@ -53,7 +53,7 @@ class HebrewDurationLocale implements DurationLocale {
     if (abbreviated) {
       return 'ח';
     } else {
-      return 'חודש';
+      return amount == 1 ? 'חודש' : 'חודשיים';
     }
   }
 
@@ -62,7 +62,7 @@ class HebrewDurationLocale implements DurationLocale {
     if (abbreviated) {
       return 'שנ.';
     } else {
-      return 'שניה';
+      return amount == 1 ? 'שניה' : 'שניות';
     }
   }
 
@@ -71,7 +71,7 @@ class HebrewDurationLocale implements DurationLocale {
     if (abbreviated) {
       return 'שב.';
     } else {
-      return 'שבוע';
+      return amount == 1 ? 'שבוע' : 'שבועות';
     }
   }
 
@@ -80,7 +80,7 @@ class HebrewDurationLocale implements DurationLocale {
     if (abbreviated) {
       return 'שנ.';
     } else {
-      return 'שנה';
+      return amount == 1 ? 'שנה' : 'שנים';
     }
   }
 }

--- a/lib/src/locale/locale.dart
+++ b/lib/src/locale/locale.dart
@@ -82,6 +82,9 @@ const ItalianDurationLocale italianLocale = ItalianDurationLocale();
 /// [DurationLocale] for German language
 const GermanDurationLocale germanLocale = GermanDurationLocale();
 
+/// [DurationLocale] for Hebrew language
+const HebrewDurationLocale hebrewLocale = HebrewDurationLocale();
+
 const _locales = <String, DurationLocale>{
   'en': englishLocale,
   'fr': frenchLocale,
@@ -92,4 +95,5 @@ const _locales = <String, DurationLocale>{
   'tr': turkishLocale,
   'it': italianLocale,
   'de': germanLocale,
+  'he': hebrewLocale,
 };

--- a/lib/src/locale/locale.dart
+++ b/lib/src/locale/locale.dart
@@ -9,6 +9,7 @@ part 'swedish.dart';
 part 'turkish.dart';
 part 'italian.dart';
 part 'german.dart';
+part 'hebrew.dart';
 
 /// Interface to print time units for different locale
 abstract class DurationLocale {

--- a/test/pretty_duration_test.dart
+++ b/test/pretty_duration_test.dart
@@ -274,6 +274,7 @@ void main() {
           milliseconds: 999,
           microseconds: 999);
       final dur2 = Duration(
+          days: 5,
           minutes: 59,
           seconds: 59,
           milliseconds: 999,
@@ -303,7 +304,7 @@ void main() {
           '5 days 23 hours 59 minutes 59 seconds');
 
       expect(prettyDuration(dur2, tersity: DurationTersity.microsecond, maxTersity: 2),
-          '59 minutes 59 seconds');
+          '5 days 59 minutes');
     });
 
     test('First', () {

--- a/test/pretty_duration_test.dart
+++ b/test/pretty_duration_test.dart
@@ -273,6 +273,11 @@ void main() {
           seconds: 59,
           milliseconds: 999,
           microseconds: 999);
+      final dur2 = Duration(
+          minutes: 59,
+          seconds: 59,
+          milliseconds: 999,
+          microseconds: 999);
 
       expect(prettyDuration(dur, tersity: DurationTersity.day), '5 days');
 
@@ -290,6 +295,15 @@ void main() {
 
       expect(prettyDuration(dur, tersity: DurationTersity.microsecond),
           '5 days 23 hours 59 minutes 59 seconds 999 milliseconds 999 microseconds');
+
+      expect(prettyDuration(dur, tersity: DurationTersity.microsecond, maxTersity: 2),
+          '5 days 23 hours');
+
+      expect(prettyDuration(dur, tersity: DurationTersity.microsecond, maxTersity: 4),
+          '5 days 23 hours 59 minutes 59 seconds');
+
+      expect(prettyDuration(dur2, tersity: DurationTersity.microsecond, maxTersity: 2),
+          '59 minutes 59 seconds');
     });
 
     test('First', () {


### PR DESCRIPTION
I added an option called maxTersity which allows the limiting of the number of time epochs that are being printed. 
This is useful if you have limited space for the time string and you don't care about losing the granularity of smaller time epochs.

I also added Hebrew locale.
It works 95% but due to syntactic differences in the Hebrew language support for the other 5% will require some architectural changes.
I will make these in a separate pull request