### PR TITLE
Replace minute abbreviation in English & French ('m' => 'min')

### DIFF
--- a/lib/src/locale/english.dart
+++ b/lib/src/locale/english.dart
@@ -51,7 +51,7 @@ class EnglishDurationLocale implements DurationLocale {
   @override
   String minute(int amount, [bool abbreviated = true]) {
     if (abbreviated) {
-      return 'm';
+      return 'min';
     } else {
       return 'minute' + (amount.abs() != 1 ? 's' : '');
     }

--- a/lib/src/locale/french.dart
+++ b/lib/src/locale/french.dart
@@ -51,7 +51,7 @@ class FrenchDurationLocale implements DurationLocale {
   @override
   String minute(int amount, [bool abbreviated = true]) {
     if (abbreviated) {
-      return 'm';
+      return 'min';
     } else {
       return 'minute' + (amount > 1 ? 's' : '');
     }


### PR DESCRIPTION
Cf https://en.wikipedia.org/wiki/International_System_of_Units#Non-SI_units_accepted_for_use_with_SI