### PR TITLE
Updated dutch minute abbreviation to min

### DIFF
--- a/lib/src/locale/dutch.dart
+++ b/lib/src/locale/dutch.dart
@@ -51,7 +51,7 @@ class DutchDurationLocale implements DurationLocale {
   @override
   String minute(int amount, [bool abbreviated = true]) {
     if (abbreviated) {
-      return 'm';
+      return 'min';
     } else {
       return amount == 1 ? 'minuut' : 'minuten';
     }


### PR DESCRIPTION
As discussed in this PR: https://github.com/desktop-dart/duration/pull/46#issuecomment-951871036
Changing minute `m` to `min` to avoid confusion with month