### PR TITLE
Add Japanese locale and Add defaultSpacer for CJK locale

### DIFF
--- a/lib/src/duration.dart
+++ b/lib/src/duration.dart
@@ -42,7 +42,7 @@ String prettyDuration(Duration duration,
     spacer = '';
   } else {
     delimiter ??= ' ';
-    spacer ??= ' ';
+    spacer ??= locale.defaultSpacer;
   }
 
   var out = <String>[];

--- a/lib/src/locale/chinese_hans.dart
+++ b/lib/src/locale/chinese_hans.dart
@@ -4,6 +4,9 @@ class ChineseSimplifiedDurationLocale extends DurationLocale {
   const ChineseSimplifiedDurationLocale();
 
   @override
+  String get defaultSpacer => '';
+
+  @override
   String year(int amount, [bool abbreviated = true]) {
     return '年';
   }

--- a/lib/src/locale/chinese_hant.dart
+++ b/lib/src/locale/chinese_hant.dart
@@ -4,6 +4,9 @@ class ChineseTraditionalDurationLocale extends DurationLocale {
   const ChineseTraditionalDurationLocale();
 
   @override
+  String get defaultSpacer => '';
+
+  @override
   String year(int amount, [bool abbreviated = true]) {
     return '年';
   }

--- a/lib/src/locale/japanese.dart
+++ b/lib/src/locale/japanese.dart
@@ -4,6 +4,9 @@ class JapaneseDurationLocale extends DurationLocale {
   const JapaneseDurationLocale();
 
   @override
+  String get defaultSpacer => '';
+
+  @override
   String year(int amount, [bool abbreviated = true]) {
     return '年';
   }

--- a/lib/src/locale/japanese.dart
+++ b/lib/src/locale/japanese.dart
@@ -1,0 +1,54 @@
+part of duration.locale;
+
+class JapaneseDurationLocale extends DurationLocale {
+  const JapaneseDurationLocale();
+
+  @override
+  String year(int amount, [bool abbreviated = true]) {
+    return '年';
+  }
+
+  @override
+  String month(int amount, [bool abbreviated = true]) {
+    return '月';
+  }
+
+  @override
+  String week(int amount, [bool abbreviated = true]) {
+    return '週';
+  }
+
+  @override
+  String day(int amount, [bool abbreviated = true]) {
+    return '日';
+  }
+
+  @override
+  String hour(int amount, [bool abbreviated = true]) {
+    if (abbreviated) {
+      return '時';
+    } else {
+      return '時間';
+    }
+  }
+
+  @override
+  String minute(int amount, [bool abbreviated = true]) {
+    return '分';
+  }
+
+  @override
+  String second(int amount, [bool abbreviated = true]) {
+    return '秒';
+  }
+
+  @override
+  String millisecond(int amount, [bool abbreviated = true]) {
+    return 'ミリ秒';
+  }
+
+  @override
+  String microseconds(int amount, [bool abbreviated = true]) {
+    return 'マイクロ秒';
+  }
+}

--- a/lib/src/locale/korean.dart
+++ b/lib/src/locale/korean.dart
@@ -4,6 +4,9 @@ class KoreanDurationLocale extends DurationLocale {
   const KoreanDurationLocale();
 
   @override
+  String get defaultSpacer => '';
+
+  @override
   String year(int amount, [bool abbreviated = true]) {
     return '년';
   }

--- a/lib/src/locale/locale.dart
+++ b/lib/src/locale/locale.dart
@@ -24,6 +24,7 @@ part 'korean.dart';
 part 'indonesian.dart';
 part 'czech.dart';
 part 'finnish.dart';
+part 'japanese.dart';
 
 /// Interface to print time units for different locale
 abstract class DurationLocale {
@@ -160,8 +161,11 @@ const ArabicDurationLocale arabicLocale = ArabicDurationLocale();
 /// [DurationLocale] for Czech language
 const CzechDurationLocale czechLocale = CzechDurationLocale();
 
-/// [DurationLocale] for Czech language
+/// [DurationLocale] for Finnish language
 const FinnishDurationLocale finnishLocale = FinnishDurationLocale();
+
+/// [DurationLocale] for Japanese language
+const JapaneseDurationLocale japaneseLocale = JapaneseDurationLocale();
 
 const _locales = <String, DurationLocale>{
   'en': englishLocale,
@@ -186,4 +190,5 @@ const _locales = <String, DurationLocale>{
   'ar': arabicLocale,
   'cz': czechLocale,
   'fi': finnishLocale,
+  'ja': japaneseLocale,
 };

--- a/lib/src/locale/locale.dart
+++ b/lib/src/locale/locale.dart
@@ -30,6 +30,8 @@ part 'japanese.dart';
 abstract class DurationLocale {
   const DurationLocale();
 
+  String get defaultSpacer => ' ';
+
   /// Print [amount] years for the corresponding locale. The unit is abbreviated
   /// if [abbreviated] is set to true.
   String year(int amount, [bool abbreviated = true]);

--- a/test/locale_test.dart
+++ b/test/locale_test.dart
@@ -1,0 +1,75 @@
+import 'package:duration/duration.dart';
+import 'package:duration/locale.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('test by language', () {
+    test('English', () {
+      const locale = EnglishDurationLocale();
+      const dur = Duration(days: 5, hours: 23);
+      expect(
+        prettyDuration(dur, locale: locale),
+        '5 days 23 hours',
+      );
+      expect(
+        prettyDuration(dur, locale: locale, abbreviated: true),
+        '5d, 23h',
+      );
+      expect(
+        prettyDuration(dur, locale: locale, abbreviated: true, delimiter: ' '),
+        '5 d 23 h',
+      );
+    });
+
+    test('Chinese', () {
+      const locale = ChineseSimplifiedDurationLocale();
+      const dur = Duration(days: 5, hours: 23);
+      expect(
+        prettyDuration(dur, locale: locale),
+        '5日 23小时',
+      );
+      expect(
+        prettyDuration(dur, locale: locale, abbreviated: true),
+        '5日, 23时',
+      );
+      expect(
+        prettyDuration(dur, locale: locale, abbreviated: true, delimiter: ' '),
+        '5日 23时',
+      );
+    });
+
+    test('Japanese', () {
+      const locale = JapaneseDurationLocale();
+      const dur = Duration(days: 5, hours: 23);
+      expect(
+        prettyDuration(dur, locale: locale),
+        '5日 23時間',
+      );
+      expect(
+        prettyDuration(dur, locale: locale, abbreviated: true),
+        '5日, 23時',
+      );
+      expect(
+        prettyDuration(dur, locale: locale, abbreviated: true, delimiter: ' '),
+        '5日 23時',
+      );
+    });
+
+    test('Korean', () {
+      const locale = KoreanDurationLocale();
+      const dur = Duration(days: 5, hours: 23);
+      expect(
+        prettyDuration(dur, locale: locale),
+        '5일 23시간',
+      );
+      expect(
+        prettyDuration(dur, locale: locale, abbreviated: true),
+        '5일, 23시',
+      );
+      expect(
+        prettyDuration(dur, locale: locale, abbreviated: true, delimiter: ' '),
+        '5일 23시',
+      );
+    });
+  });
+}


### PR DESCRIPTION
Hi, I just added Japanese locale.

and I added `defaultSpacer` to `DurationLocale` for CJK locale. 
It should be no space between value and unit on CJK locale.

```dart
const dur = Duration(days: 5, hours: 23);

prettyDuration(dur, locale: ChineseSimplifiedDurationLocale())
// current: '5 日 23 小时'
// changed: '5日 23小时'

prettyDuration(dur, locale: JapaneseDurationLocale())
// current: '5 日 23 時間'
// changed: '5日 23時間'

prettyDuration(dur, locale: KoreanDurationLocale())
// current: '5 일 23 시간'
// changed: '5일 23시간'
```

Thank you!