### PR TITLE
[CJK] update hour() about abbreviation

### DIFF
--- a/lib/src/locale/chinese_hans.dart
+++ b/lib/src/locale/chinese_hans.dart
@@ -28,11 +28,7 @@ class ChineseSimplifiedDurationLocale extends DurationLocale {
 
   @override
   String hour(int amount, [bool abbreviated = true]) {
-    if (abbreviated) {
-      return '时';
-    } else {
-      return '小时';
-    }
+    return '小时';
   }
 
   @override

--- a/lib/src/locale/chinese_hant.dart
+++ b/lib/src/locale/chinese_hant.dart
@@ -28,11 +28,7 @@ class ChineseTraditionalDurationLocale extends DurationLocale {
 
   @override
   String hour(int amount, [bool abbreviated = true]) {
-    if (abbreviated) {
-      return '時';
-    } else {
-      return '小時';
-    }
+    return '小時';
   }
 
   @override

--- a/lib/src/locale/japanese.dart
+++ b/lib/src/locale/japanese.dart
@@ -28,11 +28,7 @@ class JapaneseDurationLocale extends DurationLocale {
 
   @override
   String hour(int amount, [bool abbreviated = true]) {
-    if (abbreviated) {
-      return '時';
-    } else {
-      return '時間';
-    }
+    return '時間';
   }
 
   @override

--- a/lib/src/locale/korean.dart
+++ b/lib/src/locale/korean.dart
@@ -28,11 +28,7 @@ class KoreanDurationLocale extends DurationLocale {
 
   @override
   String hour(int amount, [bool abbreviated = true]) {
-    if (abbreviated) {
-      return '시';
-    } else {
-      return '시간';
-    }
+    return '시간';
   }
 
   @override


### PR DESCRIPTION
I fixed wrong expressions. these shouldn't be abbreviated.

`时 / 時 / 시` are units used to indicate specific time. (e.g. _at 1 o' clock_)

`小时 / 小時 / 時間 / 시간` are units used to indicate duration. (e.g. _it takes 1 hour._)